### PR TITLE
Experiment: shapes

### DIFF
--- a/brainwallet.xcodeproj/project.pbxproj
+++ b/brainwallet.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		247D74F32DA907FB00855B14 /* BRSet.c in Sources */ = {isa = PBXBuildFile; fileRef = 249C45972D936D5900E9C3B0 /* BRSet.c */; };
 		247D74F42DA907FB00855B14 /* BRTransaction.c in Sources */ = {isa = PBXBuildFile; fileRef = 249C45992D936D5900E9C3B0 /* BRTransaction.c */; };
 		247D74F52DA907FB00855B14 /* BRWallet.c in Sources */ = {isa = PBXBuildFile; fileRef = 249C459B2D936D5900E9C3B0 /* BRWallet.c */; };
+		248E5C3D2DE76612003F232F /* BrainwalletShapes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 248E5C3C2DE765FD003F232F /* BrainwalletShapes.swift */; };
 		2492829C2DAC22B00088528E /* BIP39Words.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2492829B2DAC22B00088528E /* BIP39Words.plist */; };
 		249C45DC2D93F23F00E9C3B0 /* service-data.plist in Resources */ = {isa = PBXBuildFile; fileRef = 249C45DB2D93F23F00E9C3B0 /* service-data.plist */; };
 		249C45E02D9415D900E9C3B0 /* AppsFlyerLib in Frameworks */ = {isa = PBXBuildFile; productRef = 249C45DF2D9415D900E9C3B0 /* AppsFlyerLib */; };
@@ -475,6 +476,7 @@
 		24618EE92D90435200A878AC /* BRCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BRCore.swift; sourceTree = "<group>"; };
 		2465873623A5AAD000A32E9E /* brainwalletTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = brainwalletTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2473D44E2DB991D90076746A /* PasscodeGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasscodeGridView.swift; sourceTree = "<group>"; };
+		248E5C3C2DE765FD003F232F /* BrainwalletShapes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrainwalletShapes.swift; sourceTree = "<group>"; };
 		2492829B2DAC22B00088528E /* BIP39Words.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = BIP39Words.plist; sourceTree = "<group>"; };
 		249C450E2D936D5900E9C3B0 /* ax_jni_include_dir.m4 */ = {isa = PBXFileReference; lastKnownFileType = text; path = ax_jni_include_dir.m4; sourceTree = "<group>"; };
 		249C450F2D936D5900E9C3B0 /* ax_prog_cc_for_build.m4 */ = {isa = PBXFileReference; lastKnownFileType = text; path = ax_prog_cc_for_build.m4; sourceTree = "<group>"; };
@@ -1145,6 +1147,14 @@
 			path = Colors;
 			sourceTree = "<group>";
 		};
+		248E5C3B2DE765F1003F232F /* Custom Shapes */ = {
+			isa = PBXGroup;
+			children = (
+				248E5C3C2DE765FD003F232F /* BrainwalletShapes.swift */,
+			);
+			path = "Custom Shapes";
+			sourceTree = "<group>";
+		};
 		249C45112D936D5900E9C3B0 /* m4 */ = {
 			isa = PBXGroup;
 			children = (
@@ -1660,6 +1670,7 @@
 		C312D2CD2D7DC27700BB97A4 /* brainwallet */ = {
 			isa = PBXGroup;
 			children = (
+				248E5C3B2DE765F1003F232F /* Custom Shapes */,
 				241B477E2DCEA05D00279954 /* Localizations */,
 				24D7AE522DCFF6350078252E /* New Onboarding */,
 				24A404212DC92F1F006CD076 /* New Buy Webview */,
@@ -2438,6 +2449,7 @@
 				C312D3492D7DC27700BB97A4 /* StartNavigationDelegate.swift in Sources */,
 				C312D34C2D7DC27700BB97A4 /* AssociatedObject.swift in Sources */,
 				C312D34D2D7DC27700BB97A4 /* StartViewController.swift in Sources */,
+				248E5C3D2DE76612003F232F /* BrainwalletShapes.swift in Sources */,
 				C312D34F2D7DC27700BB97A4 /* DispatchQueue+Additions.swift in Sources */,
 				C312D3512D7DC27700BB97A4 /* DataValidation.swift in Sources */,
 				C312D3532D7DC27700BB97A4 /* TransactionModalView.swift in Sources */,

--- a/brainwallet/Custom Shapes/BrainwalletShapes.swift
+++ b/brainwallet/Custom Shapes/BrainwalletShapes.swift
@@ -1,0 +1,99 @@
+//
+//  BrainwalletShapes.swift
+//  brainwallet
+//
+//  Created by Kerry Washington on 28/05/2025.
+//  Copyright © 2025 Grunt Software, LTD. All rights reserved.
+//
+import SwiftUI
+
+struct BrainwalletHexagon: Shape {
+    
+    func path(in rect: CGRect) -> Path {
+        let width = rect.width
+        let height = rect.height
+        let centerX = rect.midX
+        let centerY = rect.midY
+                
+        // Calculate hexagon points (flat-top orientation)
+        let radius = min(width, height) / 2
+                
+        var path = Path()
+                
+        // Start from top vertex and go clockwise (pointy-top orientation)
+        path.move(to: CGPoint(x: centerX, y: centerY - radius))
+        path.addLine(to: CGPoint(x: centerX + radius * sin(π/3), y: centerY - radius * cos(π/3)))
+        path.addLine(to: CGPoint(x: centerX + radius * sin(π/3), y: centerY + radius * cos(π/3)))
+        path.addLine(to: CGPoint(x: centerX, y: centerY + radius))
+        path.addLine(to: CGPoint(x: centerX - radius * sin(π/3), y: centerY + radius * cos(π/3)))
+        path.addLine(to: CGPoint(x: centerX - radius * sin(π/3), y: centerY - radius * cos(π/3)))
+        path.closeSubpath()
+        return path
+        
+    }
+}
+
+
+
+struct TestShapeView: View {
+    
+       @State
+       private var progress = 0.0
+    
+    var body: some View {
+        GeometryReader { geometry in
+            
+            let width = geometry.size.width
+            let height = geometry.size.height
+            
+            ZStack {
+                BrainwalletColor.surface.edgesIgnoringSafeArea(.all)
+               
+                VStack {
+                    
+                    
+                    ZStack {
+                        BrainwalletHexagon()
+                            .fill(BrainwalletColor.affirm)
+                        
+                        BrainwalletHexagon()
+                            .trim(from: 0, to: progress)
+                            .stroke(BrainwalletColor.affirm.opacity(0.5),
+                                    style: StrokeStyle(lineWidth: 3, lineCap: .round))
+                    }
+                    .frame(width: 30, height: 30)
+                    .onAppear {
+                        withAnimation(.easeInOut(duration: 1.0).repeatForever(autoreverses: false)) {
+                            progress = 1.0
+                        }
+                    }
+                    
+                    BrainwalletHexagon()
+                        .fill(.red)
+                        .overlay(
+                            BrainwalletHexagon()
+                                .stroke(Color.blue, lineWidth: 2)
+                        )
+                    
+                    ZStack {
+                        BrainwalletHexagon()
+                            .fill(BrainwalletColor.background)
+                        
+                        BrainwalletHexagon()
+                            .trim(from: 0, to: progress)
+                            .stroke(BrainwalletColor.content.opacity(0.5),
+                                    style: StrokeStyle(lineWidth: 3, lineCap: .round))
+                    }
+                    .frame(width: 100, height: 100)
+                    .onAppear {
+                        withAnimation(.easeInOut(duration: 1.0).repeatForever(autoreverses: false)) {
+                            progress = 1.0
+                        }
+                    }
+                    
+                }
+                 
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Task
The sending paradigm is incorrect and we need to show the users what is actually happening.
Currently, when a user sends it shows 20%, 40%...complete. This is misleading and confusing.
We need to educate the user what is actually happening.

## Facts
There are several steps that happen in the sending of Litecoin and we need to have a way to express this to the users.
There are actually 9 stages:

1. Signed transaction (commit to the UXTO)
2. Publish transaction to the network
3. Transaction is in the Litecoin networks mempool
4. Node/Peer accepts the transaction as valid (1 of  6 confirmations )
5. Node/Peer accepts the transaction as valid (2 of  6 confirmations )
6. Node/Peer accepts the transaction as valid (3 of  6 confirmations )
7. Node/Peer accepts the transaction as valid (4 of  6 confirmations )
8. Node/Peer accepts the transaction as valid (5 of  6 confirmations )
9. Node/Peer accepts the transaction as valid (6 of  6 confirmations ) transaction is permanent


## Idea
We can add nice graphic for users to understand the stages. There is a concept Figma here: https://www.figma.com/design/9IP5iHEq0jxxujWA9sg2n2/brainwallet-app-ui-ux?node-id=3693-4230&t=8q4A1EoFkz41Ua3U-1

Thinking this can be 8 stages:
| Stage | Animation / Draw |
|--------------|------------------|
| Signed | Hex appears |
| In the Mempool | Outline animation |
| First Confirmation | 1 Green triangle wedge |
| Second Confirmation | 2 Green triangle wedge |
| Third Confirmation | 3 Green triangle wedge |
| Fourth Confirmation | 4 Green triangle wedge |
| Fifth Confirmation | 5 Green triangle wedge |
| Sixth Confirmation | 6 Green triangle wedge |


| Sketch Hexagon |
|------------------|
|![drafthex](https://github.com/user-attachments/assets/67262c7e-0482-427b-912c-467bd2b5af07)|
